### PR TITLE
v2.0.0a3 Bugfixes, better init handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ And use type `Integration`. Once installed, proceed to follow README in the 'jvc
 #### Command Strings:
 These command strings will perform an operation on the projector. The corresponding entry in the `last_commands_response` attribute will be `success` if the operation succeeded, or `failed` otherwise. Values in '{}' indicate multiple choices.
 * **Power:** `power-{on,off}` (recommended to use the `remote.turn_on` and `remote.turn_off` services).
-* **Lens Memory:** `memory-{1-10}`
+* **Lens Memory:** `memory-{1-10}` (Not all projectors will have all 10)
 * **Source:** `input-{hdmi1, hdmi2}`
-* **Picture Mode:** `picture_mode-{cinema, natural, film, THX, hlg, hdr10}`, `picture_mode-{user1-user6}`
+* **Picture Mode:** `picture_mode-{cinema, natural, film, THX, hlg, hdr10}`, `picture_mode-{user1-user6}`, **NZ Series:** `frame_adapt_hdr`, `hdr10p`, `pana_pq`
 * **Low Latency Mode:** `low_latency-{on, off}`
 * **Mask** `mask-{off, custom1, custom2, custom3}`
-* **Lamp** `lamp-{high,low}`
+* **Lamp** `lamp-{high,low}`, **NZ Series:** `mid`
 * **Menu Controls** `menu-{menu, up, down, left, right, ok, back}`
 * **Lens Aperture** `aperture-{off, auto1, auto2}`
 * **Anamorphic** `anamorphic-{off, a, b, c}`
@@ -165,7 +165,7 @@ These command strings will store the response from the projector in the correspo
 * **Mask** `mask`, returns from `off, custom1, custom2, custom3`
 * **Lamp** `lamp`, returns from `high, low`
 * **Lens Aperture** `aperture`, returns from `off, auto1, auto2`
-* **Anamorphic** `anamorphic`, returns from `off, a, b, c`
+* **Anamorphic** `anamorphic`, returns from `off, a, b, c`, **NZ Series:** `d`
 * **MAC Address** `macaddr`, returns the projector's MAC address
 * **Model Info** `modelinfo`, returns the model string of the projector
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ And use type `Integration`. Once installed, proceed to follow README in the 'jvc
 #### Command Strings:
 These command strings will perform an operation on the projector. The corresponding entry in the `last_commands_response` attribute will be `success` if the operation succeeded, or `failed` otherwise. Values in '{}' indicate multiple choices.
 * **Power:** `power-{on,off}` (recommended to use the `remote.turn_on` and `remote.turn_off` services).
-* **Lens Memory:** `memory-{1-5}`
+* **Lens Memory:** `memory-{1-10}`
 * **Source:** `input-{hdmi1, hdmi2}`
 * **Picture Mode:** `picture_mode-{cinema, natural, film, THX, hlg, hdr10}`, `picture_mode-{user1-user6}`
 * **Low Latency Mode:** `low_latency-{on, off}`

--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -2,10 +2,10 @@
   "domain": "jvcprojector",
   "name": "JVC Projector IP Control",
   "documentation": "https://github.com/bezmi/hass_custom_components",
-  "requirements": ["jvc-projector-remote == 0.2.0a3"],
+  "requirements": ["jvc-projector-remote == 0.2.0"],
   "dependencies": [],
   "codeowners": [
     "@bezmi"
   ],
-  "version": "2.0.0a3"
+  "version": "2.0.0"
 }

--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -2,10 +2,10 @@
   "domain": "jvcprojector",
   "name": "JVC Projector IP Control",
   "documentation": "https://github.com/bezmi/hass_custom_components",
-  "requirements": ["jvc-projector-remote == 0.2.0a2"],
+  "requirements": ["jvc-projector-remote == 0.2.0a3"],
   "dependencies": [],
   "codeowners": [
     "@bezmi"
   ],
-  "version": "2.0.0a1"
+  "version": "2.0.0a3"
 }

--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -7,5 +7,5 @@
   "codeowners": [
     "@bezmi"
   ],
-  "version": "2.0.0"
+  "version": "2.0.0a3"
 }

--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -2,7 +2,7 @@
   "domain": "jvcprojector",
   "name": "JVC Projector IP Control",
   "documentation": "https://github.com/bezmi/hass_custom_components",
-  "requirements": ["jvc-projector-remote == 0.2.0"],
+  "requirements": ["jvc-projector-remote == 0.2.1"],
   "dependencies": [],
   "codeowners": [
     "@bezmi"

--- a/custom_components/jvcprojector/remote.py
+++ b/custom_components/jvcprojector/remote.py
@@ -5,6 +5,9 @@ from homeassistant import util
 import asyncio
 from typing import Final
 from jvc_projector_remote import JVCCommunicationError as comm_error
+from jvc_projector_remote import JVCConfigError as conf_error
+from jvc_projector_remote import JVCCannotConnectError as connect_error
+from jvc_projector_remote import JVCProjector
 import datetime
 
 JVC_RETRIES: Final = "max_retries"
@@ -52,15 +55,28 @@ class JVCRemote(remote.RemoteEntity):
         retries: int | None,
     ) -> None:
         """Initialize the Remote."""
-        from jvc_projector_remote import JVCProjector
 
-        self._name = name or DEVICE_DEFAULT_NAME
-        self._host = host
-        self._password = password
+        self._conf_name = name or DEVICE_DEFAULT_NAME
+        self._conf_host = host
+        self._conf_password = password
+        self._conf_port = 20554 if port is None else port
+        self._conf_delay = delay
+        self._conf_timeout=timeout
+        self._conf_retries = retries
 
         self._last_commands_sent = None
-        self._jvc = JVCProjector(host, password, port, delay, timeout, retries)
-        self._power_state = self._jvc.power_state()
+
+        try:
+            self._jvc = JVCProjector(self._conf_host, self._conf_password, self._conf_port, self._conf_delay, self._conf_timeout, self._conf_retries)
+        except conf_error as e:
+            _LOGGER.warning(f"Couldn't set up the componenent due to the following error")
+            raise e
+
+        self._power_state = "not_connected" if not self._jvc.validate_connection() else self._jvc.power_state()
+
+        if self._power_state == "not_connected":
+            _LOGGER.warning(f"Initial connection test to the projector at {self._conf_host}:{self._conf_port} failed. Please check your configuration")
+
         self._state = True if self._power_state == "lamp_on" else False
         self._signal_state = (
             "unknown" if not self._state else self._jvc.command("signal")
@@ -82,7 +98,7 @@ class JVCRemote(remote.RemoteEntity):
     @property
     def name(self) -> str:
         """Return the name of the device if any."""
-        return self._name
+        return self._conf_name
 
     async def async_update(self):
         await self.async_update_state()
@@ -129,6 +145,19 @@ class JVCRemote(remote.RemoteEntity):
         """Send a command to a device."""
 
         async with self.state_lock:
+
+            if self._power_state is "not_connected":
+                _LOGGER.warning(f"The projector is not connected, cannot send command")
+                (
+                    self._input_state,
+                    self._signal_state,
+                    self._picture_mode_state,
+                    self._lamp_state,
+                ) = ("unknown", "unknown", "unknown", "unknown")
+                self._last_commands_sent = []
+                self._last_commands_response = []
+                return
+
             if type(command) != list:
                 command = [command]
 
@@ -148,13 +177,21 @@ class JVCRemote(remote.RemoteEntity):
                 except comm_error as e:
                     # The projector is powered off
                     _LOGGER.warning(
-                        f"Failed to send command, could not communicate with projector: {repr(e)}\nThis could happen if the command only works when the projector is on but the current state is off, or the timeout setting is too low"
+                        f"Failed to send command, could not communicate with projector: {repr(e)}\nThis could happen if the command only works when the projector is on but the current state is off or the timeout setting is too low."
                     )
                     self._last_commands_sent.append(com)
                     self._last_commands_response.append("failed")
+                except connect_error as e:
+                    # the projector is likely off at the mains
+                    _LOGGER.warning(f"The projector at {self._conf_host}:{self._conf_port} did not respond to the connection request.")
+                    self._power_state = "not_connected"
+                    self._last_commands_sent = []
+                    self._last_commands_response = []
+                    return
+
                 except Exception as e:
                     # when an error occured during sending, command execution probably failed
-                    _LOGGER.error(f"Unknown error, abort sending commands")
+                    _LOGGER.error(f"Unhandled error, abort sending commands")
                     self._last_commands_sent = ["unknown"]
                     self._last_commands_response = ["failed"]
                     raise e
@@ -173,6 +210,22 @@ class JVCRemote(remote.RemoteEntity):
         # do nothing until lock is released
         if self.state_lock.locked():
             return
+
+        # in case the init of the JVCProjector object failed due to a JVCConfigError
+        if self._power_state == "not_connected":
+            is_connected = await self.hass.async_add_executor_job(self._jvc.validate_connection)
+            if not is_connected:
+                _LOGGER.warning(f"Couldn't connect to the projector at the specified address: {self._conf_host}:{self._conf_port}. Ensure the configuration is correct.")
+                self._power_state = "not_connected"
+                (
+                    self._input_state,
+                    self._signal_state,
+                    self._picture_mode_state,
+                    self._lamp_state,
+                ) = ("unknown", "unknown", "unknown", "unknown")
+                self._last_commands_sent = []
+                self._last_commands_response = []
+                return
 
         try:
             self._power_state = await self.hass.async_add_executor_job(
@@ -201,6 +254,36 @@ class JVCRemote(remote.RemoteEntity):
                 self._jvc.command, ("lamp")
             )
 
-        except Exception as e:
+        except connect_error as e:
+            _LOGGER.warning(f"The projector at {self._conf_host}:{self._conf_port} did not respond to the connection request.")
+            self._power_state = "not_connected"
+            (
+                self._input_state,
+                self._signal_state,
+                self._picture_mode_state,
+                self._lamp_state,
+            ) = ("unknown", "unknown", "unknown", "unknown")
+            self._last_commands_sent = ["power"]
+            self._last_commands_response = ["failed"]
+            return
+        except comm_error as e:
+            _LOGGER.warning(
+                f"Failed to check power state, could not communicate with projector: {repr(e)}."
+            )
             self._power_state = "unknown"
+            (
+                self._input_state,
+                self._signal_state,
+                self._picture_mode_state,
+                self._lamp_state,
+            ) = ("unknown", "unknown", "unknown", "unknown")
+            self._last_commands_sent = ["power"]
+            self._last_commands_response = ["failed"]
+            return
+
+        except Exception as e:
+            _LOGGER.error(f"Unhandled error occured")
+            self._power_state = "unknown"
+            self._last_commands_sent = ["power"]
+            self._last_commands_response = ["failed"]
             raise e


### PR DESCRIPTION
Once the upstream lib 0.2.1 has been tested and pushed, this PR should close:

- #13: if we can't connect to projector on init, there will be a warning logged, but initialisation will continue as it may become available later
- #18: mostly an upstream fix, if an unknown response which can't be decoded into a pretty string is sent by the projector, instead of a `KeyError`, it will now log a warning and return the raw response ascii code.
- #17: add picture modes, lamp power 'mid', anamorphic 'd', extra lens memory options for the NZ series

If there are volunteers to test the new NZ projectors, then this should be close a final v2.0.0 release.